### PR TITLE
fix: disable too strict openapi validation

### DIFF
--- a/openapi/validate.go
+++ b/openapi/validate.go
@@ -6,10 +6,6 @@ import (
 )
 
 func (openapi *OpenAPI) Validate(ctx context.Context) error {
-	if err := openapi.doc.Validate(ctx); err != nil {
-		return fmt.Errorf("the OpenAPI file is not valid: %w", err)
-	}
-
 	if openapi.BaseUrl() == nil {
 		return fmt.Errorf("no valid base url has been found in OpenAPI file")
 	}


### PR DESCRIPTION
disable openapi3 mod validation. Some validation like the info object is not relevant for API Scanning.