### PR TITLE
Fix URL typo in jwt-weak-secret vulnerability report

### DIFF
--- a/scan/broken_authentication/jwt/weak_secret/weak_secret.go
+++ b/scan/broken_authentication/jwt/weak_secret/weak_secret.go
@@ -20,7 +20,7 @@ const (
 var issue = report.Issue{
 	ID:   "broken_authentication.weak_secret",
 	Name: "JWT Secret used for signing is weak",
-	URL:  "https://www.cerberauth.com/docs/vulnapi/docs/vulnerabilities/broken-authentication/jwt-weak-secret?utm_source=vulnapi-report",
+	URL:  "https://www.cerberauth.com/docs/vulnapi/vulnerabilities/broken-authentication/jwt-weak-secret?utm_source=vulnapi-report",
 
 	Classifications: &report.Classifications{
 		OWASP: report.OWASP_2023_BrokenAuthentication,


### PR DESCRIPTION
The documentation URL for the jwt-weak-secret vulnerability incorrectly contains 'vulnapi/docs/vulnapi' instead of just 'vulnapi', causing the link to return a 404.

**Changed:**
- Fixed URL in  from:
  
  to:
  